### PR TITLE
Fix/link separators

### DIFF
--- a/index.html
+++ b/index.html
@@ -277,9 +277,30 @@
         }
 
             .c-nav-secondary__item {
-                display: inline;
+                position: relative;
+                display: inline-block;
                 padding-right: calc((var(--ratio) * 1rem) / 2);
                 padding-left: calc((var(--ratio) * 1rem) / 2);
+            }
+
+            .c-nav-secondary__item + .c-nav-secondary__item {
+                margin-left: -.2779em;
+            }
+
+            .c-nav-secondary__item:after {
+                content: '|';
+                position: absolute;
+                top: 0;
+                right: 0;
+                transform: translateX(50%);
+            }
+
+
+            /**
+             * Last child selector no worky in IE8 and earlier
+             */
+            .c-nav-secondary__item:last-child:after {
+                content: '';
             }
 
                 .c-nav-secondary__link {
@@ -420,13 +441,11 @@
                         <li class="c-nav-secondary__item">
                             <a href="https://github.com/andycochrane" class="c-nav-secondary__link" target="_blank" rel="noopener">Github</a>
                         </li>
-                        <span> | </span>
                         <li class="c-nav-secondary__item">
                             <a href="https://gist.github.com/andycochrane" class="c-nav-secondary__link" target="_blank" rel="noopener">Gist</a>
                         </li>
-                        <span> | </span>
                         <li class="c-nav-secondary__item">
-                            <a href="https://codepen.io/andycochrane/" class="c-nav-secondary__link" target="_blank" rel="noopener">Codepen</a>
+                            <a href="https://codepen.io/andycochrane" class="c-nav-secondary__link" target="_blank" rel="noopener">Codepen</a>
                         </li>
                     </ul>
                 </nav>

--- a/index.html
+++ b/index.html
@@ -283,10 +283,6 @@
                 padding-left: calc((var(--ratio) * 1rem) / 2);
             }
 
-            .c-nav-secondary__item + .c-nav-secondary__item {
-                margin-left: -.2779em;
-            }
-
             .c-nav-secondary__item:after {
                 content: '|';
                 position: absolute;
@@ -440,11 +436,11 @@
                     <ul class="c-nav-secondary">
                         <li class="c-nav-secondary__item">
                             <a href="https://github.com/andycochrane" class="c-nav-secondary__link" target="_blank" rel="noopener">Github</a>
-                        </li>
-                        <li class="c-nav-secondary__item">
+                        </li><!--
+                        --><li class="c-nav-secondary__item">
                             <a href="https://gist.github.com/andycochrane" class="c-nav-secondary__link" target="_blank" rel="noopener">Gist</a>
-                        </li>
-                        <li class="c-nav-secondary__item">
+                        </li><!--
+                        --><li class="c-nav-secondary__item">
                             <a href="https://codepen.io/andycochrane" class="c-nav-secondary__link" target="_blank" rel="noopener">Codepen</a>
                         </li>
                     </ul>

--- a/index.html
+++ b/index.html
@@ -291,7 +291,6 @@
                 transform: translateX(50%);
             }
 
-
             /**
              * Last child selector no worky in IE8 and earlier
              */

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-var cacheName = 'andycochrane:0004';
+var cacheName = 'andycochrane:0005';
 var cacheFiles = [
   '/',
   '/assets/img/logo-arriva.png',
@@ -49,7 +49,7 @@ self.addEventListener('fetch', function(event) {
 // Empty out any caches that don’t match the ones listed.
 self.addEventListener('activate', function(event) {
 
-  var cacheWhitelist = ['andycochrane:0004'];
+  var cacheWhitelist = ['andycochrane:0005'];
 
   event.waitUntil(
     caches.keys().then(function(cacheNames) {


### PR DESCRIPTION
Removed the spans which had no place amongst list items and used pseudo elements instead.

As it is, it is still using a vertical bar character as the separator. Would you recommend using a border or a 1 pixel wide element with background colour instead?